### PR TITLE
Additional Python exe paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ enable_language(RC)
 set(CMAKE_RC_COMPILE_OBJECT
     "<CMAKE_RC_COMPILER> <FLAGS> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
 set(PYTHON_VERSION "3.9" CACHE STRING "Python version to support")
+string(REPLACE "." "" PYVER_NO_DOTS "${PYTHON_VERSION}")
 
 ########################################################################
 # Create gnuradio-companion executable
@@ -22,6 +23,7 @@ set(PYTHON_VERSION "3.9" CACHE STRING "Python version to support")
 set(CMAKE_EXE_LINKER_FLAGS "/entry:mainCRTStartup ${CMAKE_EXE_LINKER_FLAGS}")
 add_executable(gnuradio-companion WIN32 gnuradio-companion.cpp ${RES_FILES})
 target_compile_definitions(gnuradio-companion PRIVATE -DPYTHON_VERSION=\"${PYTHON_VERSION}\")
+target_compile_definitions(gnuradio-companion PRIVATE -DPYVER_NO_DOTS=\"${PYVER_NO_DOTS}\")
 
 ########################################################################
 # Install gnuradio-companion executable

--- a/GNURadioHelper.py
+++ b/GNURadioHelper.py
@@ -143,7 +143,7 @@ def handle_import_gtk():
     pip_install('wheel') #wheel needed for this file type:
     print('Downloading and installing pygtk + gtk runtime:')
     print('     The module is large, this may take time...')
-    pip_install('http://downloads.myriadrf.org/binaries/python39_amd64/PothosSDRPyGTK-2021.1.21-cp39-cp39-win_amd64.whl')
+    pip_install('http://downloads.myriadrf.org/binaries/python39_amd64/PothosSDRPyGTK-2021.2.16-cp39-cp39-win_amd64.whl')
 
 ########################################################################
 ## GNU Radio checks

--- a/gnuradio-companion.cpp
+++ b/gnuradio-companion.cpp
@@ -91,10 +91,14 @@ static std::string getPythonExePath(void)
     std::vector<std::string> paths;
 
     std::string errorMsg("Failed to find amd64 python.exe:\n");
+
+    //list the HKEY_LOCAL_MACHINE search path as well
+    errorMsg += "[HKLM]" + regPath + "\n";
+
     for (const auto &path : {
-        getPythonExePathLocalUser(),
-        getPythonExePathGlobalUser(),
-        getPythonExePathRegistry()})
+        getPythonExePathRegistry(), //prefer python found in the registry key
+        getPythonExePathGlobalUser(), //next check the default program files install path
+        getPythonExePathLocalUser()}) //and then the local user appdata install path
     {
         if (path.empty()) continue;
         DWORD binaryType;
@@ -106,9 +110,6 @@ static std::string getPythonExePath(void)
         else paths.push_back(path);
         errorMsg += "\n";
     }
-
-    //list the HKEY_LOCAL_MACHINE search path as well
-    errorMsg += "[HKLM]" + regPath + "\n";
 
     //found a result, return the first one
     if (not paths.empty()) return paths.front();


### PR DESCRIPTION
* closes https://github.com/pothosware/PothosSDR/issues/86
* supports searching for default python install paths outside of registry